### PR TITLE
update default backoff jitter algo base

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
     "@types/chai": "^4.2.10",
     "@types/chai-as-promised": "^7.1.2",
     "@types/mocha": "^5.2.7",
+    "@types/node": "^12.0.2",
     "@types/sinon": "^7.0.13",
     "@typescript-eslint/eslint-plugin": "^2.5.0",
     "@typescript-eslint/parser": "^2.5.0",
@@ -32,9 +33,8 @@
     "nyc": "^14.1.1",
     "sinon": "^7.3.2",
     "ts-node": "^8.3.0",
-    "typedoc": "^0.15.0",
-    "typescript": "^3.8.0",
-    "@types/node": "^12.0.2"
+    "typedoc": "^0.23.20",
+    "typescript": "^3.8.0"
   },
   "peerDependencies": {
     "aws-sdk": "^2.841.0",

--- a/src/retry/DefaultRetryConfig.ts
+++ b/src/retry/DefaultRetryConfig.ts
@@ -26,11 +26,9 @@ const SLEEP_BASE_MS: number = 10;
  * 
  * @internal
  */
-export const defaultBackoffFunction: BackoffFunction = (retryAttempt: number, error: Error, transactionId: string) => {
-    const exponentialBackoff: number = Math.min(SLEEP_CAP_MS, Math.pow(SLEEP_BASE_MS * 2,  retryAttempt));
-    const jitterRand: number = Math.random();
-    const delayTime: number = jitterRand * exponentialBackoff;
-    return delayTime;
+export const defaultBackoffFunction: BackoffFunction = (retryAttempt: number, error: Error, transactionId: string):number => {
+    const fullJitterBackoffMax: number = Math.min(SLEEP_CAP_MS, SLEEP_BASE_MS * 2 ** retryAttempt);
+    return Math.random() * fullJitterBackoffMax;
 }
 
 export const defaultRetryConfig: RetryConfig = new RetryConfig(4, defaultBackoffFunction);


### PR DESCRIPTION
Issue #, if available:
n/a

Description of changes:
Part of qldb driver implementation sync for retries. QLDB drivers implemented full jitter slightly differently.
jitter algorithm is sleep_base * 2 ** retry_attempts
was implemented as sleep_base ** retry_attempt

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.